### PR TITLE
Description popup, reaction emojis, QoL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.4-slim
+FROM python:3.12.4-slim
 
 RUN apt-get update
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   psybot:
     build: .

--- a/psybot/main.py
+++ b/psybot/main.py
@@ -5,7 +5,7 @@ import discord
 import pymongo.errors
 from discord import app_commands
 
-from psybot.modules import ctf, ctftime, challenge, notes, psybot
+from psybot.modules import ctf, ctftime, challenge, notes, bot
 from psybot.config import config
 from psybot.database import db
 from psybot.utils import setup_settings
@@ -22,7 +22,7 @@ challenge.add_commands(tree, guild_obj)
 ctf.add_commands(tree, guild_obj)
 ctftime.add_commands(tree, guild_obj)
 notes.add_commands(tree, guild_obj)
-psybot.add_commands(tree, guild_obj)
+bot.add_commands(tree, guild_obj)
 
 
 @client.event

--- a/psybot/modules/bot.py
+++ b/psybot/modules/bot.py
@@ -42,7 +42,7 @@ SETTINGS_TYPES = {
     'ctftime_team': str,
 }
 
-class PsybotCommands(app_commands.Group):
+class BotCommands(app_commands.Group):
     @app_commands.command(description="Update guild settings")
     @app_commands.guild_only
     @app_commands.choices(key=[app_commands.Choice(name=name, value=name) for name in SETTINGS_TYPES.keys()])
@@ -109,4 +109,4 @@ class PsybotCommands(app_commands.Group):
 
 
 def add_commands(tree: app_commands.CommandTree, guild: Optional[discord.Object]):
-    tree.add_command(PsybotCommands(name="psybot"), guild=guild)
+    tree.add_command(BotCommands(name="bot"), guild=guild)

--- a/psybot/modules/challenge.py
+++ b/psybot/modules/challenge.py
@@ -41,6 +41,10 @@ async def category_autocomplete_nullable(interaction: discord.Interaction, curre
     return out
 
 
+def category_is_valid(category: str, guild_id: int) -> bool:
+    return category is None or CtfCategory.objects(name=category, guild_id=guild_id)
+
+
 def get_work_embeds(chall_db: Challenge):
     embeds = []
     for w in WORK_VALUES[1:]:
@@ -48,6 +52,7 @@ def get_work_embeds(chall_db: Challenge):
         if work_list:
             embeds.append(discord.Embed(color=w.color).add_field(name=w.name, value=", ".join(f"<@!{work.user}>" for work in work_list)))
     return embeds
+
 
 async def update_work_message(chall_db: Challenge, channel: Optional[discord.PartialMessageable]):
     if channel:
@@ -107,47 +112,77 @@ async def add(interaction: discord.Interaction, category: str, name: str):
                                                 f"wait for an admin to delete some channels. {admin_role.mention}",
                                                 allowed_mentions=discord.AllowedMentions.all())
         return
+
     incomplete_category = get_incomplete_category(interaction.guild)
 
-    ctf = sanitize_channel_name(ctf_db.name)
-    name = sanitize_channel_name(name)
-
-    if category:
-        category = sanitize_channel_name(category)
-        fullname = f"{ctf}-{category}-{name}"
-    else:
-        category = None
-        fullname = f"{ctf}-{name}"
-
+    # Check category is valid
+    category = sanitize_channel_name(category) if category else None
     settings = get_settings(interaction.guild)
-    if settings.enforce_categories:
-        if category is not None and not CtfCategory.objects(name=category, guild_id=interaction.guild_id):
-            raise app_commands.AppCommandError("Invalid CTF category")
+    if settings.enforce_categories and not category_is_valid(category, interaction.guild_id):
+        raise app_commands.AppCommandError("Invalid CTF category")
 
-    if old_chall := Challenge.objects(name=name, category=category, ctf=ctf_db).first():
-        if interaction.guild.get_channel(old_chall.channel_id):
-            raise app_commands.AppCommandError("A challenge with that name already exists")
-        else:
-            old_chall.delete()
+    ctf = sanitize_channel_name(ctf_db.name)
 
-    new_channel = await create_channel(fullname, interaction.channel.overwrites, incomplete_category)
-    work_message_id = None
-    if settings.send_work_message:
-        work_message = await new_channel.send(view=WorkView())
-        await work_message.pin()
-        work_message_id = work_message.id
+    class ChallengeInfoModal(ui.Modal, title="Add Challenge"):
+        name_field = ui.TextInput(
+            label="Name",
+            default=name,
+            placeholder="Challenge name"
+        )
+        category_field = ui.TextInput(
+            label="Category",
+            default=category,
+            placeholder="Challenge category"
+        )
+        description_field = ui.TextInput(
+            label="Description",
+            style=discord.TextStyle.paragraph,
+            placeholder="Challenge description",
+            max_length=1000
+        )
 
-    chall_db = Challenge(name=name, category=category, channel_id=new_channel.id, ctf=ctf_db, work_message=work_message_id)
-    chall_db.save()
+        async def on_submit(self, submit_interaction: discord.Interaction):
+            name = sanitize_channel_name(self.name_field.value)
+            if self.category_field.value:
+                category = sanitize_channel_name(self.category_field.value)
+                if settings.enforce_categories and not category_is_valid(category, interaction.guild_id):
+                    await submit_interaction.response.send_message("Invalid CTF category", ephemeral=True)
+                    return
+                channel_name = f"{ctf}-{category}-{name}"[:100]
+            else:
+                category = None
+                channel_name = f"{ctf}-{name}"[:100]
 
-    if category:
-        ctf_category = CtfCategory.objects(name=category, guild_id=interaction.guild_id).first()
-        if ctf_category is None:
-            ctf_category = CtfCategory(name=category, guild_id=interaction.guild_id, count=0)
-        ctf_category.count += 1
-        ctf_category.save()
+            if old_chall := Challenge.objects(name=name, category=category, ctf=ctf_db).first():
+                if interaction.guild.get_channel(old_chall.channel_id):
+                    await submit_interaction.response.send_message("A challenge with that name already exists", ephemeral=True)
+                    return
+                else:
+                    old_chall.delete()
 
-    await interaction.response.send_message("Added challenge {}".format(new_channel.mention))
+            new_channel = await create_channel(channel_name, interaction.channel.overwrites, incomplete_category)
+            await new_channel.send(f"# {self.name_field.value}\n\n{self.description_field.value}")
+
+            work_message_id = None
+            if settings.send_work_message:
+                work_message = await new_channel.send(view=WorkView())
+                await work_message.pin()
+                work_message_id = work_message.id
+
+            chall_db = Challenge(name=name, category=category, channel_id=new_channel.id, ctf=ctf_db, work_message=work_message_id)
+            chall_db.save()
+
+            if category:
+                ctf_category = CtfCategory.objects(name=category, guild_id=interaction.guild_id).first()
+                if ctf_category is None:
+                    ctf_category = CtfCategory(name=category, guild_id=interaction.guild_id, count=0)
+                ctf_category.count += 1
+                ctf_category.save()
+
+            await submit_interaction.response.send_message("Added challenge {}".format(new_channel.mention))
+
+    info = ChallengeInfoModal()
+    await interaction.response.send_modal(info)
 
 
 @app_commands.command(description="Marks a challenge as done")

--- a/psybot/modules/challenge.py
+++ b/psybot/modules/challenge.py
@@ -206,12 +206,18 @@ async def done(interaction: discord.Interaction, contributors: Optional[str]):
 
     await move_channel(interaction.channel, get_complete_category(interaction.guild))
 
-    # Easter egg, use special emojis for firehawk
+    # Special emojis for certain users, otherwise default
+    emojis = {
+        286173785336446978: (":fire:", "firepog"),  # firehawk
+        112158630161158144: (":punch:", "noshell"),  # N1z0ku
+        145301884662448128: (":flag_no:", "chadtor"),  # Victor4X
+        634877910511255575: (":lemon: :last_quarter_moon_with_face:", "lightsaberpepe"),  # Anakin
+    }
     msg_emoji = ":tada:"
     reaction_emoji = "peepoBrunner"
-    if len(users) == 1 and users[0] == 286173785336446978:
-        msg_emoji = ":fire:"
-        reaction_emoji = "firepog"
+
+    if len(users) == 1 and users[0] in emojis:
+        msg_emoji, reaction_emoji = emojis[users[0]]
 
     solvers = " ".join(f"<@!{user}>" for user in users)
     msg = f"{msg_emoji}  {interaction.channel.mention} was solved by {solvers}!  {msg_emoji}"

--- a/psybot/modules/challenge.py
+++ b/psybot/modules/challenge.py
@@ -194,6 +194,7 @@ async def done(interaction: discord.Interaction, contributors: Optional[str]):
     users = chall_db.solvers
     if interaction.user.id not in users:
         users.append(interaction.user.id)
+
     if contributors is not None:
         for user in [int(i) for i in re.findall(r'<@!?(\d+)>', contributors)]:
             if user not in users:
@@ -205,8 +206,21 @@ async def done(interaction: discord.Interaction, contributors: Optional[str]):
 
     await move_channel(interaction.channel, get_complete_category(interaction.guild))
 
-    msg = ":tada: {} was solved by ".format(interaction.channel.mention) + " ".join(f"<@!{user}>" for user in users) + " !"
-    await interaction.guild.get_channel(ctf_db.channel_id).send(msg)
+    # Easter egg, use special emojis for firehawk
+    msg_emoji = ":tada:"
+    reaction_emoji = "peepoBrunner"
+    if len(users) == 1 and users[0] == 286173785336446978:
+        msg_emoji = ":fire:"
+        reaction_emoji = "firepog"
+
+    solvers = " ".join(f"<@!{user}>" for user in users)
+    msg = f"{msg_emoji}  {interaction.channel.mention} was solved by {solvers}!  {msg_emoji}"
+    sent_msg = await interaction.guild.get_channel(ctf_db.channel_id).send(msg)
+
+    # Pre-react to solver message
+    emoji = discord.utils.get(interaction.guild.emojis, name=reaction_emoji)
+    await sent_msg.add_reaction(emoji)
+
     await interaction.response.send_message("Challenge moved to done!")
 
 

--- a/psybot/modules/ctf.py
+++ b/psybot/modules/ctf.py
@@ -8,7 +8,6 @@ import discord
 from discord import app_commands
 from discord import ui
 
-from psybot.models.ctf_category import CtfCategory
 from psybot.utils import *
 from psybot.modules.ctftime import Ctftime
 from psybot.config import config
@@ -293,7 +292,7 @@ class CtfCommands(app_commands.Group):
                 chall.delete()
         await interaction.edit_original_response(content="The CTF has been renamed")
 
-    @app_commands.command(description="Export an archived CTF")
+    @app_commands.command(description="Export a CTF")
     @app_commands.guild_only
     @app_commands.check(is_team_admin)
     async def export(self, interaction: discord.Interaction):

--- a/psybot/utils.py
+++ b/psybot/utils.py
@@ -1,3 +1,5 @@
+import re
+
 import discord
 from discord import app_commands
 
@@ -8,7 +10,7 @@ MAX_CHANNELS = 500
 CATEGORY_MAX_CHANNELS = 50
 
 
-def get_category_pos(category_channel: discord.CategoryChannel, name: str):
+def get_category_pos(category_channel: discord.CategoryChannel, name: str) -> int:
     if name.count("-") == 1:
         ctf, category = name.split("-")[0], None
     else:
@@ -35,7 +37,7 @@ def get_category_pos(category_channel: discord.CategoryChannel, name: str):
         return 0
 
 
-async def get_backup_category(original_category: discord.CategoryChannel):
+async def get_backup_category(original_category: discord.CategoryChannel) -> discord.CategoryChannel:
     last_backup = None
     for cat in BackupCategory.objects(original_id=original_category.id).order_by('index'):
         last_backup = cat
@@ -63,7 +65,7 @@ async def delete_channel(channel: discord.TextChannel):
     await free_backup_category(original_category)
 
 
-async def create_channel(name: str, overwrites: dict, category: discord.CategoryChannel, challenge=True):
+async def create_channel(name: str, overwrites: dict, category: discord.CategoryChannel, challenge=True) -> discord.TextChannel:
     if len(category.channels) == CATEGORY_MAX_CHANNELS:
         category = await get_backup_category(category)
 
@@ -98,25 +100,28 @@ async def is_team_admin(interaction: discord.Interaction) -> bool:
 
 
 _channel_name_translation = {ord(i): '' for i in '''!"#$%&'()*+,./:;<=>?@[\\]^`{|}~'''}
-_channel_name_translation[ord(' ')] = '_'
-_channel_name_translation[ord('-')] = '_'
+_channel_name_translation |= {ord(' '): '_', ord('-'): '_'}
 def sanitize_channel_name(name: str) -> str:
-    return name.translate(_channel_name_translation).lower()
+    name = re.sub(r"<:.+?:\d+?>", "", name)  # Remove emojis
+    name = name.translate(_channel_name_translation).lower()
+    return re.sub(r"_+", "_", name).strip("_")
 
 
-def _discord_get(guild: discord.Guild, value: int, id_type: str):
+def _discord_get(guild: discord.Guild, value: int, id_type: str) -> discord.Role | discord.abc.GuildChannel | None:
     if id_type == "role":
         return guild.get_role(value)
     elif id_type == "channel" or id_type == "category":
         return guild.get_channel(value)
 
-def _discord_find(guild: discord.Guild, name: str, id_type: str):
+
+def _discord_find(guild: discord.Guild, name: str, id_type: str) -> discord.Role | discord.abc.GuildChannel | None:
     if id_type == "role":
         return discord.utils.get(guild.roles, name=name)
     elif id_type == "channel":
         return discord.utils.get(guild.channels, name=name)
     elif id_type == "category":
         return discord.utils.get(guild.categories, name=name)
+
 
 def _discord_create(guild: discord.Guild, name: str, id_type: str):
     if id_type == "role":
@@ -125,6 +130,7 @@ def _discord_create(guild: discord.Guild, name: str, id_type: str):
         return guild.create_text_channel(name=name)
     elif id_type == "category":
         return guild.create_category_channel(name=name)
+
 
 async def setup_settings(guild: discord.Guild):
     settings = GuildSettings.objects(guild_id=guild.id).first()
@@ -157,6 +163,7 @@ async def setup_settings(guild: discord.Guild):
     for member in guild.members:
         if member.guild_permissions.administrator and member != guild.me:
             await member.add_roles(guild.get_role(settings.admin_role), guild.get_role(settings.team_role))
+
 
 def get_settings(guild: discord.Guild) -> GuildSettings:
     if guild is None:
@@ -198,6 +205,7 @@ def _get_category(guild: discord.Guild, category_name: str) -> discord.CategoryC
     if category is None:
         raise app_commands.AppCommandError("'{0}' category missing. Fix this with /psybot set {0} <category_id>".format(category_name))
     return category
+
 
 get_ctfs_category = lambda g: _get_category(g, 'ctfs_category')
 get_incomplete_category = lambda g: _get_category(g, 'incomplete_category')

--- a/psybot/utils.py
+++ b/psybot/utils.py
@@ -102,7 +102,7 @@ async def is_team_admin(interaction: discord.Interaction) -> bool:
 _channel_name_translation = {ord(i): '' for i in '''!"#$%&'()*+,./:;<=>?@[\\]^`{|}~'''}
 _channel_name_translation |= {ord(' '): '_', ord('-'): '_'}
 def sanitize_channel_name(name: str) -> str:
-    name = re.sub(r"<:.+?:\d+?>", "", name)  # Remove emojis
+    name = re.sub(r"<a?:.+?:\d+?>", "", name)  # Remove emojis
     name = name.translate(_channel_name_translation).lower()
     return re.sub(r"_+", "_", name).strip("_")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-discord.py~=2.3
-tabulate~=0.8.9
-mongoengine~=0.25.0
-aiohttp~=3.8.3
-beautifulsoup4~=4.11.1
+beautifulsoup4~=4.12.3
 diff-match-patch
-matplotlib~=3.6.2
+discord.py~=2.4.0
+matplotlib~=3.9.0
+mongoengine~=0.28.2
+tabulate~=0.9.0


### PR DESCRIPTION
## Changes

- `/add` command now opens a modal with name and category pre-filled from the command args but with an additional description text field. `enforce_categories` still holds for the category field. Upon submission, the challenge name (unsanitized) and description are posted to the challenge channel. This helps enforce the description is always posted, which enables easier teamwork and enriches the channel for later export and archiving.
- Bot now pre-reacts to solve messages upon `/done`, making it more natural for other players to follow and help celebrate victories. As an easter egg, certain specific team players get their own special emojis.
- Sanitization has been improved to auto-remove emojis, combine multiple underscores into one, and strip leading/trailing underscores, giving a much nicer short name for challs with more complex names
- Python and dependency version have been bumped to newest stable
- Rename "psybot" settings slash commands to just "bot" (`/bot set` and `/bot info`)