### PR TITLE
Various QoL updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ BrunnerBot adds a number of slash commands for easy and effective CTF management
     * `/invite <user>`: Add a new player
     * `/remove <user>`: Remove a current player - players can leave manually with `/leave`
   * When a CTFtime link is supplied, most CTF information is automatically entered
-    * Manually update info such as team credentials with `/ctf update <field> <value>`
+    * Manually update info such as team credentials and Discord link with `/ctf update <field> <value>`
   * When `private` is set, team members are not automatically added to the CTF and must all be invited with `/invite`
   * `/ctf rename <name>`: Rename CTF if needed - very short names recommended to fit in channel list
 * `/add <category> <name>`: Create new challenge (description is entered in popup modal)

--- a/brunnerbot/models/ctf.py
+++ b/brunnerbot/models/ctf.py
@@ -7,6 +7,7 @@ class Ctf(Document):
     role_id = LongField(required=True)
     info = DictField(required=False)
     info_id = LongField(required=True)
+    password_id = LongField(required=False)
     private = BooleanField(required=True)
     archived = BooleanField(required=True, default=False)
     meta = {

--- a/brunnerbot/modules/challenge.py
+++ b/brunnerbot/modules/challenge.py
@@ -157,18 +157,19 @@ async def add(interaction: discord.Interaction, category: str, name: str):
         name_field = ui.TextInput(
             label="Name",
             default=name,
-            placeholder="Challenge name"
+            placeholder="Challenge name",
         )
         category_field = ui.TextInput(
             label="Category",
             default=category,
-            placeholder="Challenge category"
+            placeholder="Challenge category",
+            required=False,
         )
         description_field = ui.TextInput(
             label="Description",
             style=discord.TextStyle.paragraph,
             placeholder="Challenge description",
-            max_length=1000
+            max_length=1000,
         )
 
         async def on_submit(self, submit_interaction: discord.Interaction):

--- a/brunnerbot/modules/ctf.py
+++ b/brunnerbot/modules/ctf.py
@@ -280,6 +280,22 @@ class CtfCommands(app_commands.Group):
                     )
                     await submit_interaction.response.send_message("Updated info", ephemeral=True)
 
+                    # Send and pin message just with password for easy copy paste
+                    regex_password = re.search(r"Password: `(.+)`", self.edit.value)
+                    if not regex_password:
+                        return
+
+                    password = regex_password.group(1)
+                    if ctf_db.password_id is None:
+                        msg = await interaction.channel.send(password)
+                        await msg.pin()
+                        ctf_db.password_id = msg.id
+                        ctf_db.save()
+                    else:
+                        await interaction.channel.get_partial_message(ctf_db.password_id).edit(
+                            content=password
+                        )
+
             await interaction.response.send_modal(CredsModal())
             return
         elif field == "url":

--- a/brunnerbot/modules/ctf.py
+++ b/brunnerbot/modules/ctf.py
@@ -111,17 +111,17 @@ async def export_channels(channels: list[discord.TextChannel]):
 
 
 def create_info_message(info):
-    msg = discord.utils.escape_mentions(info["title"])
+    msg = f"## {discord.utils.escape_mentions(info['title'])}"
     if "start" in info or "end" in info:
         msg += "\n"
     if "start" in info:
-        msg += f"\n**START** <t:{info['start']}:R> <t:{info['start']}>"
+        msg += f"\n**START:** <t:{info['start']}:R> <t:{info['start']}>"
     if "end" in info:
-        msg += f"\n**END** <t:{info['end']}:R> <t:{info['end']}>"
+        msg += f"\n**END:** <t:{info['end']}:R> <t:{info['end']}>"
     if "url" in info:
-        msg += f"\n\n{info['url']}"
+        msg += f"\n\nCTF Link: {info['url']}"
     if "creds" in info:
-        msg += "\n\n**CREDENTIALS**\n" + discord.utils.escape_mentions(info["creds"])
+        msg += f"\n\n### CREDENTIALS\n\n{discord.utils.escape_mentions(info['creds'])}"
     return msg
 
 


### PR DESCRIPTION
This adds multiple nice improvements and fixes a few bugs:
* **Feature:** Add `discord` as CTF info field for CTF Discord links
* **Feature:** Allow force deletion of CTFs from any channel - enables deletion of accidentally orphaned CTFs
* **Improvement:** Better CTF info message formatting
* **Improvement:** Send and pin a message with password on credential update
* **Improvement:** Prevent CTF creation with same name as an existing - if existing is orphaned, allow creation if graceful deletion is possible.
* **Bugfix:** Make challenge category optional in creation modal